### PR TITLE
Add export for useGetOrganizationConfig in organization queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "repository": {

--- a/src/queries/organization/index.ts
+++ b/src/queries/organization/index.ts
@@ -1,4 +1,5 @@
 export * from "./useGetOrganization";
+export * from "./useGetOrganizationConfig";
 export * from "./useGetOrganizationExplore";
 export * from "./useGetOrganizationPage";
 export * from "./useGetOrganizationSubscriptionProducts";

--- a/src/queries/organization/useGetOrganizationConfig.ts
+++ b/src/queries/organization/useGetOrganizationConfig.ts
@@ -1,0 +1,33 @@
+import type { ConnectedXMResponse, OrganizationConfig } from "@interfaces";
+import useConnectedSingleQuery, {
+  SingleQueryOptions,
+  SingleQueryParams,
+} from "../useConnectedSingleQuery";
+import { QueryKey } from "@tanstack/react-query";
+import { GetClientAPI } from "@src/ClientAPI";
+
+export const ORGANIZATION_CONFIG_QUERY_KEY = (): QueryKey => [
+  "ORGANIZATION_CONFIG",
+];
+
+export interface GetOrganizationConfigParams extends SingleQueryParams {}
+
+export const GetOrganizationConfig = async ({
+  clientApiParams,
+}: GetOrganizationConfigParams): Promise<
+  ConnectedXMResponse<OrganizationConfig>
+> => {
+  const clientApi = await GetClientAPI(clientApiParams);
+  const { data } = await clientApi.get(`/organization/config`);
+  return data;
+};
+
+export const useGetOrganizationConfig = (
+  options: SingleQueryOptions<ReturnType<typeof GetOrganizationConfig>> = {}
+) => {
+  return useConnectedSingleQuery<ReturnType<typeof GetOrganizationConfig>>(
+    ORGANIZATION_CONFIG_QUERY_KEY(),
+    (params: SingleQueryParams) => GetOrganizationConfig({ ...params }),
+    options
+  );
+};


### PR DESCRIPTION
### Description

This separates the get config from the get organization which is necessary as they are two different needs

### Linear Issues

- ref CXM-106

### Testing

Besides the automated tests, please manually verify the following:

- [x] I have manually tested the changes
- [x] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [x] Bug fixes - Patch version bump
