### PR TITLE
Fix subscribed contents hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "7.10.1",
+  "version": "7.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "7.10.1",
+      "version": "7.10.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",
@@ -3467,9 +3467,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "7.10.1",
+  "version": "7.10.2",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/queries/contents/useGetSubscribedContents.ts
+++ b/src/queries/contents/useGetSubscribedContents.ts
@@ -61,9 +61,9 @@ export const useGetSubscribedContents = (
   return useConnectedInfiniteQuery<
     Awaited<ReturnType<typeof GetSubscribedContents>>
   >(
-    SUBSCRIBED_CONTENTS_QUERY_KEY(interest),
+    SUBSCRIBED_CONTENTS_QUERY_KEY(type, interest),
     (params: InfiniteQueryParams) =>
-      GetSubscribedContents({ interest, ...params }),
+      GetSubscribedContents({ type, interest, ...params }),
     params,
     options
   );


### PR DESCRIPTION
…k.json, and update follow-redirects dependency to 1.16.0

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1649

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch that adjusts React Query caching/fetch params for `useGetSubscribedContents` plus a dependency/SDK version bump; main risk is changed cache keys causing refetches for existing consumers.
> 
> **Overview**
> Fixes `useGetSubscribedContents` to *properly scope caching and requests by content `type`* by including `type` in `SUBSCRIBED_CONTENTS_QUERY_KEY` and forwarding it into `GetSubscribedContents`.
> 
> Bumps the package version to `7.10.2` and updates `follow-redirects` in `package-lock.json` to `1.16.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bfb4c7d253237d58dbda38cd5084ab813fcc4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->