### PR TITLE
Groups explore and Contents explore hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "7.10.2",
+  "version": "7.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "7.10.2",
+      "version": "7.10.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",
@@ -5055,9 +5055,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "7.10.2",
+  "version": "7.10.3",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/queries/contents/index.ts
+++ b/src/queries/contents/index.ts
@@ -1,2 +1,3 @@
 export * from "./useGetContents";
 export * from "./useGetSubscribedContents";
+export * from "./useGetContentsExplore";

--- a/src/queries/contents/useGetContentsExplore.ts
+++ b/src/queries/contents/useGetContentsExplore.ts
@@ -1,0 +1,56 @@
+import {
+  GetBaseSingleQueryKeys,
+  SingleQueryOptions,
+  SingleQueryParams,
+  useConnectedSingleQuery,
+} from "../useConnectedSingleQuery";
+import type { Channel, Content } from "@interfaces";
+import { QueryClient, QueryKey } from "@tanstack/react-query";
+import { ConnectedXMResponse } from "@interfaces";
+import { GetClientAPI } from "@src/ClientAPI";
+
+export interface ContentsExploreData {
+  featuredChannels: Channel[];
+  featuredContents: Content[];
+  upcomingContents: Content[];
+  pastContents: Content[];
+}
+
+export const CONTENTS_EXPLORE_QUERY_KEY = (): QueryKey => ["CONTENTS_EXPLORE"];
+
+export const SET_CONTENTS_EXPLORE_QUERY_DATA = (
+  client: QueryClient,
+  keyParams: Parameters<typeof CONTENTS_EXPLORE_QUERY_KEY>,
+  response: Awaited<ReturnType<typeof GetContentsExplore>>,
+  baseKeys: Parameters<typeof GetBaseSingleQueryKeys> = ["en"]
+) => {
+  client.setQueryData(
+    [
+      ...CONTENTS_EXPLORE_QUERY_KEY(...keyParams),
+      ...GetBaseSingleQueryKeys(...baseKeys),
+    ],
+    response
+  );
+};
+
+export interface GetContentsExploreProps extends SingleQueryParams {}
+
+export const GetContentsExplore = async ({
+  clientApiParams,
+}: GetContentsExploreProps): Promise<
+  ConnectedXMResponse<ContentsExploreData>
+> => {
+  const clientApi = await GetClientAPI(clientApiParams);
+  const { data } = await clientApi.get(`/contents/explore`);
+  return data;
+};
+
+export const useGetContentsExplore = (
+  options: SingleQueryOptions<ReturnType<typeof GetContentsExplore>> = {}
+) => {
+  return useConnectedSingleQuery<ReturnType<typeof GetContentsExplore>>(
+    CONTENTS_EXPLORE_QUERY_KEY(),
+    (params) => GetContentsExplore({ ...params }),
+    options
+  );
+};

--- a/src/queries/groups/index.ts
+++ b/src/queries/groups/index.ts
@@ -13,3 +13,4 @@ export * from "./useGetGroupInvitations";
 export * from "./useGetGroupsFeatured";
 export * from "./useGetGroupsInvited";
 export * from "./useGetGroupsRequested";
+export * from "./useGetGroupsExplore";

--- a/src/queries/groups/useGetGroupsExplore.ts
+++ b/src/queries/groups/useGetGroupsExplore.ts
@@ -1,0 +1,53 @@
+import {
+  GetBaseSingleQueryKeys,
+  SingleQueryOptions,
+  SingleQueryParams,
+  useConnectedSingleQuery,
+} from "../useConnectedSingleQuery";
+import type { Group } from "@interfaces";
+import { QueryClient, QueryKey } from "@tanstack/react-query";
+import { ConnectedXMResponse } from "@interfaces";
+import { GetClientAPI } from "@src/ClientAPI";
+
+export interface GroupsExploreData {
+  featuredGroups: Group[];
+  publicGroups: Group[];
+  privateGroups: Group[];
+}
+
+export const GROUPS_EXPLORE_QUERY_KEY = (): QueryKey => ["GROUPS_EXPLORE"];
+
+export const SET_GROUPS_EXPLORE_QUERY_DATA = (
+  client: QueryClient,
+  keyParams: Parameters<typeof GROUPS_EXPLORE_QUERY_KEY>,
+  response: Awaited<ReturnType<typeof GetGroupsExplore>>,
+  baseKeys: Parameters<typeof GetBaseSingleQueryKeys> = ["en"]
+) => {
+  client.setQueryData(
+    [
+      ...GROUPS_EXPLORE_QUERY_KEY(...keyParams),
+      ...GetBaseSingleQueryKeys(...baseKeys),
+    ],
+    response
+  );
+};
+
+export interface GetGroupsExploreProps extends SingleQueryParams {}
+
+export const GetGroupsExplore = async ({
+  clientApiParams,
+}: GetGroupsExploreProps): Promise<ConnectedXMResponse<GroupsExploreData>> => {
+  const clientApi = await GetClientAPI(clientApiParams);
+  const { data } = await clientApi.get(`/groups/explore`);
+  return data;
+};
+
+export const useGetGroupsExplore = (
+  options: SingleQueryOptions<ReturnType<typeof GetGroupsExplore>> = {}
+) => {
+  return useConnectedSingleQuery<ReturnType<typeof GetGroupsExplore>>(
+    GROUPS_EXPLORE_QUERY_KEY(),
+    (params) => GetGroupsExplore({ ...params }),
+    options
+  );
+};


### PR DESCRIPTION
…k.json, and add new exports for useGetContentsExplore and useGetGroupsExplore

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1649

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new React Query hooks and query key helpers without changing existing query behavior; main risk is cache key collisions or API contract mismatches for the new `/explore` endpoints.
> 
> **Overview**
> Adds new React Query hooks `useGetContentsExplore` and `useGetGroupsExplore` to fetch “explore” aggregates from the new `/contents/explore` and `/groups/explore` endpoints, including typed response shapes and `SET_*_QUERY_DATA` helpers for seeding the cache.
> 
> Bumps the package version to `7.10.3` and updates the lockfile (notably `postcss` to `8.5.12`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6964f102af83631e4b362e2fd5f4931021b8294a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->