### PR TITLE
chore: Bump package version to 8.0.1 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3338,12 +3338,15 @@ export interface EventConfig {
     visibility: TicketVisibility;
     limitPerAccount: number | null;
     countryCodes: string | null;
-    groupPassDescription: string | null;
     minQuantityPerSale: number;
     maxQuantityPerSale: number;
     requiresApproval: boolean;
     requireCoupon: boolean;
     requiredPassTypeId: string | null;
+    enableCoupons: boolean;
+    minCouponQuantity: number;
+    maxCouponQuantity: number | null;
+    groupPassDescription: string | null;
     priceSchedules: {
       name: string | null;
       price: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3344,16 +3344,16 @@ export interface EventConfig {
     requiresApproval: boolean;
     requireCoupon: boolean;
     requiredPassTypeId: string | null;
-    enableCoupons: boolean;
-    minCouponQuantity: number;
-    maxCouponQuantity: number | null;
-    groupPassDescription: string | null;
     priceSchedules: {
       name: string | null;
       price: number;
       startDate: string;
       endDate: string;
     }[];
+    enableCoupons: boolean;
+    maxCouponQuantity: number | null;
+    minCouponQuantity: number;
+    groupPassDescription: string | null;
     allowedGroupPassTiersIds: string[];
     allowedTiersIds: string[];
     disallowedTiersIds: string[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3430,6 +3430,17 @@ export interface EventConfig {
     disallowedTiersIds: string[];
     soldout: boolean;
   }[];
+  HAS_SESSIONS_STEP: boolean;
+  SESSIONS: {
+    id: string;
+    name: string;
+    description: string;
+    price: number;
+    startTime: string;
+    soldout: boolean;
+    allowedPassTypes: string[];
+    allowedTiers: string[];
+  }[];
   SECTIONS: {
     id: string;
     name: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1657,6 +1657,10 @@ export interface RegistrationDraftPass {
     code: string;
     discountPercent: number | null;
     discountAmount: number | null;
+    applyToPassType: boolean;
+    applyToAddOns: boolean;
+    applyToReservation: boolean;
+    applyToSessions: boolean;
   } | null;
   packageId: string | null;
   responses: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -891,6 +891,7 @@ export interface BaseCoupon {
   applyToPassType: boolean;
   applyToAddOns: boolean;
   applyToReservation: boolean;
+  applyToSessions: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1651,6 +1651,7 @@ export interface RegistrationDraftPass {
   alternateId?: number;
   passTypeId: string;
   addOnIds: string[];
+  sessionIds: string[];
   coupon: {
     id: string;
     code: string;


### PR DESCRIPTION
….json, and update CURRENCY_DISPLAY type in EventConfig interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1803

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Type-only changes can be compile-time breaking for SDK consumers (e.g., newly required `sessionIds` and added coupon/session fields), but no runtime logic is modified.
> 
> **Overview**
> Bumps the npm package version from `8.0.0` to `8.0.1` in `package.json` and `package-lock.json`.
> 
> Expands TypeScript interfaces to cover session-aware registration and coupon behavior: adds `applyToSessions` to `BaseCoupon`, adds `sessionIds` plus coupon applicability flags to `RegistrationDraftPass`, and extends `EventConfig` with a sessions step (`HAS_SESSIONS_STEP`, `SESSIONS`) and additional per-pass-type coupon controls (`enableCoupons`, `minCouponQuantity`, `maxCouponQuantity`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd86e9d3e1588c62bfe7fbbd18265b80c9aa554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->