### PR TITLE
chore: Bump package version to 8.0.2 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3477,6 +3477,7 @@ export interface EventConfig {
     required: boolean;
     validation?: string;
     validationMessage?: string;
+    searchListId: string | null;
     choices?: {
       id: string;
       text?: string;


### PR DESCRIPTION
….json, and add searchListId property to EventConfig interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1803

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Type-only change but `EventConfig.QUESTIONS[].searchListId` is added as a required field, which may break TypeScript consumers that construct or mock this shape. Version bump is low risk but should be coordinated with downstream SDK users.
> 
> **Overview**
> Bumps the SDK package version from `8.0.1` to `8.0.2` in `package.json` and `package-lock.json`.
> 
> Extends the `EventConfig` interface by adding a non-optional `searchListId: string | null` on `QUESTIONS[]` entries, enabling event registration questions to reference a search list in config responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a340413c9b88ab9fc4135f2fbcc603b41c96f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->