### PR TITLE
chore: Bump package version to 8.0.3 in package.json and add location…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.2",
+      "version": "8.0.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3478,6 +3478,7 @@ export interface EventConfig {
     validation?: string;
     validationMessage?: string;
     searchListId: string | null;
+    locationOption: LocationQuestionOption | null;
     choices?: {
       id: string;
       text?: string;


### PR DESCRIPTION
…Option property to EventConfig interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- closes ENG-1803

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch release that only updates package metadata and adds an optional field to a TypeScript interface; primary risk is downstream type incompatibility for consumers expecting the previous `EventConfig.QUESTIONS` shape.
> 
> **Overview**
> Bumps `@connectedxm/client` version from `8.0.2` to `8.0.3` (including `package-lock.json`).
> 
> Extends `EventConfig.QUESTIONS` in `src/interfaces.ts` to include `locationOption: LocationQuestionOption | null`, enabling event config question definitions to carry location granularity settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369aa201be81f9515ac55a4aa39542fa96349f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->