### PR TITLE
chore: Bump package version to 8.0.5 in package.json and add image pr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.4",
+      "version": "8.0.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3352,6 +3352,7 @@ export interface EventConfig {
     price: number;
     shortDescription: string;
     longDescription: string | null;
+    featured: boolean;
     image: {
       id: string;
       uri: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3469,6 +3469,12 @@ export interface EventConfig {
     price: number;
     startTime: string;
     soldout: boolean;
+    image: {
+      id: string;
+      uri: string;
+      width: number;
+      height: number;
+    } | null;
     allowedPassTypes: string[];
     allowedTiers: string[];
   }[];


### PR DESCRIPTION
…operty to EventConfig interface for enhanced event representation

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1803

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new required fields to the `EventConfig` TypeScript interface, which can break downstream consumers that construct/mock these objects. Otherwise changes are limited to a patch version bump and lockfile updates.
> 
> **Overview**
> Bumps the npm package version from `8.0.4` to `8.0.5` (including `package-lock.json`).
> 
> Extends the `EventConfig` interface in `src/interfaces.ts` by adding a `featured: boolean` flag on `PASS_TYPES` entries and an optional `image` object on `SESSIONS` entries to support richer event configuration data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1841780a9176b0b9d90d5b6d5b1a2ed08b16cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->