### PR TITLE
chore: Bump package version to 8.0.6 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.5",
+      "version": "8.0.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1653,11 +1653,18 @@ export interface RegistrationDraftPass {
   passTypeId: string;
   addOns: {
     id: string;
+    addOnId: string;
     price?: number;
     discount?: number;
     total?: number;
   }[];
-  sessions: { id: string; price?: number; discount?: number; total?: number }[];
+  accesses: {
+    id: string;
+    sessionId: string;
+    price?: number;
+    discount?: number;
+    total?: number;
+  }[];
   coupon: {
     id: string;
     code: string;


### PR DESCRIPTION
….json, and update RegistrationDraftPass interface to include addOnId and price properties for enhanced pricing management

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1803

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a public TypeScript interface used by consumers (replacing `sessions` with `accesses` and changing `addOns` shape), which can be breaking for downstream code despite being type-only.
> 
> **Overview**
> Bumps the SDK package version from `8.0.5` to `8.0.6` in `package.json` and `package-lock.json`.
> 
> Updates the `RegistrationDraftPass` interface to enrich draft pricing details by adding `addOnId` and per-item `price/discount/total` on `addOns`, and by modeling session-related charges under a new `accesses` array (removing the prior `sessions` field).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907b249bc14519e76f97a542e90d0b7cd929405a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->