### PR TITLE
chore: Bump package version to 8.0.9 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.8",
+      "version": "8.0.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3483,7 +3483,7 @@ export interface EventConfig {
     name: string;
     description: string;
     price: number;
-    prices: { passTypeId: string; price: number }[];
+    prices: SessionPrice[];
     startTime: string;
     soldout: boolean;
     allowedPassTypes: string[];


### PR DESCRIPTION
….json, and update EventConfig interface to use SessionPrice for pricing details

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1843

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch release that only updates package metadata and a TypeScript interface type; main impact is potential downstream compile errors for consumers expecting the old inline `prices` shape.
> 
> **Overview**
> Bumps the npm package version from `8.0.8` to `8.0.9` in `package.json` and `package-lock.json`.
> 
> Updates `EventConfig.SESSIONS[].prices` in `src/interfaces.ts` to use the shared `SessionPrice[]` type instead of an inline `{ passTypeId; price }[]` definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018a801eee3a4a7872aa2fb13f46cfc0c2e9e7cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->