### PR TITLE
chore: Bump package version to 8.0.10 in package.json and package-loc…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.9",
+  "version": "8.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.9",
+      "version": "8.0.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.9",
+  "version": "8.0.10",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3483,11 +3483,11 @@ export interface EventConfig {
     name: string;
     description: string;
     price: number;
-    prices: SessionPrice[];
     startTime: string;
     soldout: boolean;
     allowedPassTypes: string[];
     allowedTiers: string[];
+    prices: { passTypeId: string; price: number }[];
     image: {
       id: string;
       uri: string;
@@ -3530,7 +3530,7 @@ export interface EventConfig {
       value: string;
       description?: string;
       subQuestionIds?: string[];
-      soldout: boolean;
+      supply: number | null;
     }[];
   }[];
   HAS_ADD_ONS_STEP: boolean;


### PR DESCRIPTION
…k.json, and update EventConfig interface to use a new pricing structure

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1814
- ref ENG-1843

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates public TypeScript interfaces for `EventConfig` (session `prices` shape and question choice availability fields), which can be breaking for SDK consumers expecting the prior types; otherwise changes are limited to a patch version bump in package metadata.
> 
> **Overview**
> Bumps the SDK version from `8.0.9` to `8.0.10` in `package.json` and `package-lock.json`.
> 
> Updates the `EventConfig` interface to reflect a new event configuration payload: session pricing is now represented as an inline `{ passTypeId, price }[]` array, and question choice availability switches from a boolean `soldout` flag to a nullable numeric `supply` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d0886d2c2d73d6a99e5cd913ef4bda62a0812b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->