### PR TITLE
Quick session registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.11",
+  "version": "8.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.11",
+      "version": "8.0.12",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.11",
+  "version": "8.0.12",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/mutations/events/useApplyEventRegistrationCoupon.ts
+++ b/src/mutations/events/useApplyEventRegistrationCoupon.ts
@@ -21,7 +21,7 @@ export const ApplyEventRegistrationCoupon = async ({
 > => {
   const clientApi = await GetClientAPI(clientApiParams);
 
-  const { data } = await clientApi.post<ConnectedXMResponse<RegistrationDraft>>(
+  const { data } = await clientApi.put<ConnectedXMResponse<RegistrationDraft>>(
     `/events/${eventId}/registration/coupon`,
     { draft, code }
   );

--- a/src/queries/events/index.ts
+++ b/src/queries/events/index.ts
@@ -25,3 +25,4 @@ export * from "./useGetEventSessionPassIntent";
 export * from "./useGetEventsExplore";
 export * from "./useGetEventRegistration";
 export * from "./useGetEventRegistrationIntent";
+export * from "./useGetEventPassSessionsIntent";

--- a/src/queries/events/useGetEventPassSessionsIntent.ts
+++ b/src/queries/events/useGetEventPassSessionsIntent.ts
@@ -94,7 +94,7 @@ export const useGetEventPassSessionsIntent = (
         !!authenticated &&
         !!eventId &&
         !!passId &&
-        !!sessionIds &&
+        sessionIds.length > 0 &&
         (options?.enabled ?? true),
     }
   );

--- a/src/queries/events/useGetEventPassSessionsIntent.ts
+++ b/src/queries/events/useGetEventPassSessionsIntent.ts
@@ -46,13 +46,11 @@ export const GetEventPassSessionsIntent = async ({
   ConnectedXMResponse<PaymentIntent>
 > => {
   const clientApi = await GetClientAPI(clientApiParams);
-  const { data } = await clientApi.get(
+  const { data } = await clientApi.post(
     `/self/events/${eventId}/attendee/passes/${passId}/sessions/intent`,
     {
-      params: {
-        sessionIds: sessionIds ? sessionIds.join(",") : "",
-        addressId,
-      },
+      sessionIds,
+      addressId,
     }
   );
 

--- a/src/queries/events/useGetEventPassSessionsIntent.ts
+++ b/src/queries/events/useGetEventPassSessionsIntent.ts
@@ -1,0 +1,101 @@
+import { ConnectedXMResponse, PaymentIntent } from "@src/interfaces";
+import useConnectedSingleQuery, {
+  SingleQueryOptions,
+  SingleQueryParams,
+} from "../useConnectedSingleQuery";
+import { QueryKey } from "@tanstack/react-query";
+import { GetClientAPI } from "@src/ClientAPI";
+import { useConnected } from "@src/hooks";
+import { SELF_EVENT_ATTENDEE_QUERY_KEY } from "../self/attendee/useGetSelfEventAttendee";
+
+export const EVENT_PASS_SESSIONS_INTENT_QUERY_KEY = (
+  eventId: string,
+  passId: string,
+  addressId: string,
+  sessionIds: string[]
+): QueryKey => {
+  const key = [
+    ...SELF_EVENT_ATTENDEE_QUERY_KEY(eventId),
+    passId,
+    "SESSIONS_INTENT",
+  ];
+
+  if (sessionIds) {
+    key.push(...sessionIds);
+  }
+
+  key.push(addressId);
+
+  return key;
+};
+
+export interface GetEventPassSessionsIntentProps extends SingleQueryParams {
+  eventId: string;
+  passId: string;
+  sessionIds: string[];
+  addressId: string;
+}
+
+export const GetEventPassSessionsIntent = async ({
+  eventId,
+  passId,
+  sessionIds,
+  addressId,
+  clientApiParams,
+}: GetEventPassSessionsIntentProps): Promise<
+  ConnectedXMResponse<PaymentIntent>
+> => {
+  const clientApi = await GetClientAPI(clientApiParams);
+  const { data } = await clientApi.get(
+    `/self/events/${eventId}/attendee/passes/${passId}/sessions/intent`,
+    {
+      params: {
+        sessionIds: sessionIds ? sessionIds.join(",") : "",
+        addressId,
+      },
+    }
+  );
+
+  return data;
+};
+
+export const useGetEventPassSessionsIntent = (
+  eventId: string = "",
+  passId: string = "",
+  addressId: string = "",
+  sessionIds: string[],
+  options: SingleQueryOptions<
+    ReturnType<typeof GetEventPassSessionsIntent>
+  > = {}
+) => {
+  const { authenticated } = useConnected();
+
+  return useConnectedSingleQuery<ReturnType<typeof GetEventPassSessionsIntent>>(
+    EVENT_PASS_SESSIONS_INTENT_QUERY_KEY(
+      eventId,
+      passId,
+      addressId,
+      sessionIds
+    ),
+    (params: SingleQueryParams) =>
+      GetEventPassSessionsIntent({
+        eventId,
+        passId,
+        addressId,
+        sessionIds,
+        ...params,
+      }),
+    {
+      staleTime: Infinity,
+      retry: false,
+      retryOnMount: false,
+      ...options,
+      enabled:
+        !!authenticated &&
+        !!eventId &&
+        !!passId &&
+        !!sessionIds &&
+        (options?.enabled ?? true),
+    }
+  );
+};


### PR DESCRIPTION
fix: Change event registration coupon API method from POST to PUT for correct coupon application, and add new query for fetching event pass session intents

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- closes CXM-[Linear Ticket Number]
- ref ENG-1838

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new client query that creates a payment intent for session registrations, which touches payment-related flows and a new API endpoint shape. Risk is moderate and mainly around correct query keying/caching and request payload expectations.
> 
> **Overview**
> Adds a new React Query hook `useGetEventPassSessionsIntent` that posts `sessionIds` and `addressId` to `/self/events/{eventId}/attendee/passes/{passId}/sessions/intent` and caches the resulting `PaymentIntent` under a new `EVENT_PASS_SESSIONS_INTENT_QUERY_KEY`.
> 
> Bumps the package version from `8.0.11` to `8.0.12` and exports the new query from `src/queries/events/index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093ee6483e6ef00823451091533b9110ebd581f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->