### PR TITLE
chore: Bump package version to 8.0.11 in package.json and package-loc…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.10",
+      "version": "8.0.11",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/mutations/events/useApplyEventRegistrationCoupon.ts
+++ b/src/mutations/events/useApplyEventRegistrationCoupon.ts
@@ -21,7 +21,7 @@ export const ApplyEventRegistrationCoupon = async ({
 > => {
   const clientApi = await GetClientAPI(clientApiParams);
 
-  const { data } = await clientApi.post<ConnectedXMResponse<RegistrationDraft>>(
+  const { data } = await clientApi.put<ConnectedXMResponse<RegistrationDraft>>(
     `/events/${eventId}/registration/coupon`,
     { draft, code }
   );


### PR DESCRIPTION
…k.json, and update API method from POST to PUT for coupon registration

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1825

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HTTP verb for applying event registration coupons from `POST` to `PUT`, which can break integrations if the backend or intermediaries expect the old method. Otherwise the diff is a simple patch version bump.
> 
> **Overview**
> Bumps the SDK version to `8.0.11` in `package.json` and `package-lock.json`.
> 
> Updates `ApplyEventRegistrationCoupon` to call the coupon endpoint with `PUT` instead of `POST` (`/events/{eventId}/registration/coupon`), aligning the client mutation with the updated API contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8122e41912e392b08c954f24c3c31d624af80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->