### PR TITLE
chore: Bump package version to 8.1.0 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.12",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.0.12",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",
@@ -2422,12 +2422,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.0.12",
+  "version": "8.1.0",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1078,6 +1078,8 @@ export interface Session extends BaseSession {
   bookmarks?: { id: string }[]; // if this array is not empty, the session is bookmarked
   meeting: BaseMeeting | null;
   streams: BaseStreamInput[];
+  autoRefundEnabled: boolean;
+  autRefundPercent: number;
   surveys: BaseSurvey[];
   activation: BaseEventActivation | null;
   times: BaseEventSessionTime[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1079,7 +1079,7 @@ export interface Session extends BaseSession {
   meeting: BaseMeeting | null;
   streams: BaseStreamInput[];
   autoRefundEnabled: boolean;
-  autRefundPercent: number;
+  autoRefundPercentage: number;
   surveys: BaseSurvey[];
   activation: BaseEventActivation | null;
   times: BaseEventSessionTime[];


### PR DESCRIPTION
….json, and add autoRefundEnabled and autoRefundPercent properties to Session interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1802

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional surface area change (types + version bump), but `axios` is updated in the lockfile which could affect HTTP behavior at runtime if consumers reinstall dependencies.
> 
> **Overview**
> Bumps the SDK version to `8.1.0` in `package.json`/`package-lock.json` and updates the lockfile’s resolved `axios` dependency to `1.16.0`.
> 
> Extends the `Session` interface (`src/interfaces.ts`) with two new fields, `autoRefundEnabled` and `autoRefundPercentage`, to expose automatic refund configuration in session payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7feb1fab9fdae50d29fe9557e40441242e10f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->