### PR TITLE
chore: Bump package version to 8.1.1 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1049,7 +1049,27 @@ export interface BaseSession {
   eventId: string;
   taxCode: string | null;
   taxIncluded: boolean;
+  autoRefundEnabled: boolean;
+  autoRefundPercentage: number;
   blocks: BaseBlock[];
+}
+
+export interface Session extends BaseSession {
+  longDescription: string | null;
+  prices?: SessionPrice[];
+  tracks: BaseTrack[];
+  speakers: BaseSpeaker[];
+  sponsors: BaseAccount[];
+  accounts?: BaseAccount[]; // if you have saved this session = Array > 0
+  bookmarks?: { id: string }[]; // if this array is not empty, the session is bookmarked
+  meeting: BaseMeeting | null;
+  streams: BaseStreamInput[];
+  surveys: BaseSurvey[];
+  activation: BaseEventActivation | null;
+  times: BaseEventSessionTime[];
+  _count: {
+    sections: number;
+  };
 }
 
 export interface BaseEventSessionTime {
@@ -1066,26 +1086,6 @@ export interface SessionPrice {
   id: string;
   passTypeId: string;
   price: number;
-}
-
-export interface Session extends BaseSession {
-  longDescription: string | null;
-  prices?: SessionPrice[];
-  tracks: BaseTrack[];
-  speakers: BaseSpeaker[];
-  sponsors: BaseAccount[];
-  accounts?: BaseAccount[]; // if you have saved this session = Array > 0
-  bookmarks?: { id: string }[]; // if this array is not empty, the session is bookmarked
-  meeting: BaseMeeting | null;
-  streams: BaseStreamInput[];
-  autoRefundEnabled: boolean;
-  autoRefundPercentage: number;
-  surveys: BaseSurvey[];
-  activation: BaseEventActivation | null;
-  times: BaseEventSessionTime[];
-  _count: {
-    sections: number;
-  };
 }
 
 export interface BaseBlock {


### PR DESCRIPTION
….json, and add autoRefundEnabled and autoRefundPercentage properties to BaseSession interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1802

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Type changes make `autoRefundEnabled`/`autoRefundPercentage` required on `BaseSession`, which may break consumers that construct or mock `BaseSession` without these fields. Package version is bumped as part of the release.
> 
> **Overview**
> Bumps the package version from `8.1.0` to `8.1.1` in `package.json` and `package-lock.json`.
> 
> Updates session type definitions so `autoRefundEnabled` and `autoRefundPercentage` are part of `BaseSession` (instead of only `Session`), and reorders related interface declarations (`BaseEventSessionTime`, `SessionPrice`) accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e265eb5788b45c1dbc0d608f075f96b1b29acc5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->