### PR TITLE
feat: Add includedNights property to EventConfig interface and slug p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3426,6 +3426,7 @@ export interface EventConfig {
       height: number;
     } | null;
     pricePerNight: boolean;
+    includedNights: number;
     allowedPassTypesIds: string[];
     allowedTiersIds: string[];
     disallowedTiersIds: string[];
@@ -3482,6 +3483,7 @@ export interface EventConfig {
   HAS_SESSIONS_STEP: boolean;
   SESSIONS: {
     id: string;
+    slug: string;
     name: string;
     description: string;
     price: number;


### PR DESCRIPTION
…roperty to SESSIONS object

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1885

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change plus a patch version bump; primary risk is downstream TypeScript compile breaks for consumers that construct `EventConfig` objects without the new required fields.
> 
> **Overview**
> Updates the SDK version to `8.1.2`.
> 
> Extends the `EventConfig` TypeScript contract by adding **required** `includedNights: number` to `ADD_ONS` entries and `slug: string` to each `SESSIONS` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003577cf2198461bdf604020c63adbe55ec95fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->