### PR TITLE
chore: Bump package version to 8.1.3 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.1.2",
+      "version": "8.1.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -273,6 +273,7 @@ export interface SelfRelationships {
   events: Record<string, boolean>;
   channels: Record<string, boolean>;
   threads: Record<string, boolean>;
+  tiers: Record<string, boolean>;
 }
 
 export interface BaseSelf {


### PR DESCRIPTION
….json, and add tiers property to SelfRelationships interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1888

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch: it only bumps the published package version and adds a new `tiers` field to a TypeScript interface, with no runtime logic changes.
> 
> **Overview**
> Bumps the SDK package version from `8.1.2` to `8.1.3` in `package.json` and `package-lock.json`.
> 
> Extends the `SelfRelationships` TypeScript interface to include a new `tiers: Record<string, boolean>` relationship map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e6b4dfc5d3de2013685bef32c5175ea49c5f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->