### PR TITLE
[ENG-1734] ci: upgrade workflows to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "22.22.1"
+          node-version: "24"
           registry-url: https://registry.npmjs.org/
 
       - name: Update npm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Bumps `actions/setup-node` `node-version` from 22 to 24 (latest LTS). The previously pinned `22.22.1` entry in `publish.yml` is loosened to `"24"`.

## Files

- `.github/workflows/tests.yml`
- `.github/workflows/publish.yml`

## Test plan

- [ ] Tests workflow runs on Node 24 and passes
- [ ] Publish workflow (manual / on release) produces a valid build under Node 24

Linear: ENG-1734