### PR TITLE
feat(EventConfig): add BUILD_MODE flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.1.4",
+      "version": "8.1.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3571,4 +3571,5 @@ export interface EventConfig {
   }[];
   // MISC
   OPTIONS: Record<string, any> | null;
+  BUILD_MODE: boolean;
 }


### PR DESCRIPTION
### Description

Adds `BUILD_MODE: boolean` to the `EventConfig` interface, mirroring the backend `EventConfig.lookUp` addition. Lets consumers branch on whether build mode is currently active for an event.

### Linear Issues

- closes ENG-1901

### Testing

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

- [x] Bug fixes - Patch version bump (8.1.4 → 8.1.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change plus a patch version bump; main impact is downstream TypeScript compile failures for consumers expecting the previous `EventConfig` shape.
> 
> **Overview**
> Updates the SDK version to `8.1.5`.
> 
> Extends the `EventConfig` TypeScript interface to include a new `BUILD_MODE: boolean` flag so consumers can detect and branch on an event’s build-mode state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 117edb8c1e40b693409d46e05c41028cbc0f6415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->