### PR TITLE
[ENG-1913] ci: gate auto-approve on AUTO_APPROVE_USERS allowlist

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   auto-approve:
-    if: github.event.label.name == 'approved'
+    if: |
+      github.event.label.name == 'approved' &&
+      contains(fromJSON(vars.AUTO_APPROVE_USERS || '[]'), github.event.sender.login)
     runs-on: ubuntu-latest
     steps:
       - name: Auto approve PR


### PR DESCRIPTION
## Summary
Refs ENG-1913.

Restricts the auto-approve workflow so it only fires when the user who applied the `approved` label is in the `AUTO_APPROVE_USERS` repository variable. Until that variable is set (a JSON array of GitHub logins, e.g. `["robfletcher"]`), the job is skipped — fail-closed by default.

The change is one extra condition on the existing job:

```yaml
if: |
  github.event.label.name == 'approved' &&
  contains(fromJSON(vars.AUTO_APPROVE_USERS || '[]'), github.event.sender.login)
```

## Post-merge action required
- Settings → Secrets and variables → Actions → Variables → New repository variable
  - Name: `AUTO_APPROVE_USERS`
  - Value: e.g. `["robfletcher"]`

(Or set as an org-level variable shared with all repos using this workflow.)

## Test plan
- [ ] Set `AUTO_APPROVE_USERS = ["<your-login>"]` and add the `approved` label as that user → job runs, review posted
- [ ] Have a user not in the allowlist add the label → job skipped, no review posted
- [ ] Clear the variable, add the label → job skipped (fail-closed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only restricts when auto-approval can run; main risk is misconfiguration causing intended auto-approvals to be skipped.
> 
> **Overview**
> Tightens the `Auto Approve PR` GitHub Actions workflow so it only auto-approves when the `approved` label is applied **by a user in an allowlist**.
> 
> The job now checks `vars.AUTO_APPROVE_USERS` (JSON array) and *fails closed* by default (empty/missing variable means the auto-approve job is skipped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642a49d4a1e2bdc4a1f8d5fe614f5db72354fd3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->