### PR TITLE
[ENG-1792] Upgrade actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,9 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0


### PR DESCRIPTION
[ENG-1792](https://linear.app/connectedxm/issue/ENG-1792)

## Summary
- Bumps `actions/checkout` to v6 (was v3/v4)
- Bumps `actions/setup-node` to v6 (was v4)

## Test plan
- [ ] CI workflows on this PR run green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CI and the npm publish workflow, so failures could block testing or releases if the new action versions behave differently. No application/runtime code is modified.
> 
> **Overview**
> Updates GitHub Actions workflows to use `actions/checkout@v6` and `actions/setup-node@v6` in `publish.yml`, `tests.yml`, and `version-check.yml`.
> 
> This is a CI-only change intended to keep the build/test/publish pipelines on the latest supported action versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf662293867b5220673fa9ea003ce41846819e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->