### PR TITLE
Update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.5",
+  "version": "8.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.1.5",
+      "version": "8.1.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.5",
+  "version": "8.1.6",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",


### PR DESCRIPTION
### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- closes CXM-[Linear Ticket Number]
- ref ENG-1804

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to CI workflow action/node version upgrades that can affect publishing/testing, plus a small API contract change adding optional `imageId` to event-activation completion.
> 
> **Overview**
> Bumps the package version to `8.1.6` and updates GitHub Actions workflows: auto-approve now only triggers for `approved` labels applied by usernames listed in `vars.AUTO_APPROVE_USERS`, and CI/publish/version-check workflows upgrade to `actions/checkout@v6`, `actions/setup-node@v6`, and Node `24`.
> 
> Extends the SDK types and mutations for image-backed event activations: expands `ImageType`, adds `imageUpload` to `BaseEventActivation`, adds `imageId`/`image` to `BaseEventActivationCompletion`, allows `useCompleteEventActivation` to send an optional `imageId`, and tightens `useUploadImage` to accept `ImageType` instead of a string union.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626f201a99266b979f96db7899d7508c87578b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->