### PR TITLE
chore: Bump package version to 8.1.7 in package.json and package-lock…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.6",
+  "version": "8.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedxm/client",
-      "version": "8.1.6",
+      "version": "8.1.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connectedxm/client",
-  "version": "8.1.6",
+  "version": "8.1.7",
   "description": "Client API javascript SDK",
   "author": "ConnectedXM Inc.",
   "type": "module",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -344,6 +344,7 @@ export interface BaseActivity {
   eventId: string | null;
   meetingId: string | null;
   pinned: boolean;
+  pinnedExplore: boolean;
   contentId: string | null;
   commentedId: string | null;
   createdAt: string;


### PR DESCRIPTION
….json, and add pinnedExplore property to BaseActivity interface

### Description

<!-- A brief description of the changes in this PR. -->

### Linear Issues

- ref ENG-1900

### Testing

Besides the automated tests, please manually verify the following:

- [ ] I have manually tested the changes
- [ ] New integration tests have been added (if applicable)

### Semantic Versioning

Indicate the appropriate version bump for this PR:

- [ ] Breaking changes - Major version bump
- [ ] New features / improvements - Minor version bump
- [ ] Bug fixes - Patch version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low runtime risk, but adding a new required `BaseActivity.pinnedExplore` field can be a TypeScript-breaking change for SDK consumers if their data/models don’t include it.
> 
> **Overview**
> Bumps the SDK version from `8.1.6` to `8.1.7` in `package.json` and `package-lock.json`.
> 
> Extends the `BaseActivity` type to include a new boolean flag, `pinnedExplore`, to represent an additional pin state exposed by the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a3d89397cd268c6b10baded5ddf0bc078f1689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->